### PR TITLE
Support --dry-run option with activity-stress-test command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,6 @@ setenv =
 commands =
     python scripts/hub-stress-test.py -v --dry-run stress-test -c 5
     python scripts/hub-stress-test.py -v --dry-run --log-to-file purge.log purge
+    python scripts/hub-stress-test.py --dry-run activity-stress-test --count 10
     cat purge.log
     rm purge.log


### PR DESCRIPTION
This plumbs the `--dry-run` option support through for the
`activity-stress-test` command so we can run it as part of Travis CI.
The only notable change is that since the Session returns a mock response
we don't have real elapsed times and need to just hard-code a value.