### PR TITLE
Fix arg order in example

### DIFF
--- a/scripts/hub-stress-test.py
+++ b/scripts/hub-stress-test.py
@@ -67,7 +67,7 @@ without actually making any changes, for example:
 
   JUPYTERHUB_API_TOKEN=test
   JUPYTERHUB_ENDPOINT=http://localhost:8000/hub/api
-  python hub-stress-test.py stress-test -v --dry-run
+  python hub-stress-test.py -v --dry-run stress-test
 ''')
     parser.add_argument('-e', '--endpoint',
                         default=os.environ.get('JUPYTERHUB_ENDPOINT'),


### PR DESCRIPTION
The `-v --dry-run` options are global and therefore
they come before the subcommand otherwise you get
an error:

>$ python hub-stress-test.py stress-test --dry-run
usage: hub-stress-test.py [-h] [-e ENDPOINT] [-t TOKEN] [--dry-run] [--log-to-file [FILEPATH]] [-v] {stress-test,activity-stress-test,purge} ...
hub-stress-test.py: error: unrecognized arguments: --dry-run