### PR TITLE
Avoid Latest Version of urllib3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 purge.log
+.venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: 3.7
+python: "3.12"
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-language: python
+dist: jammy
 
+language: python
 python: "3.12"
 
 cache: pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-urllib3<2
+urllib3>=2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-urllib3
+urllib3<2

--- a/scripts/hub-stress-test.py
+++ b/scripts/hub-stress-test.py
@@ -226,7 +226,7 @@ def get_session(token, dry_run=False, pool_maxsize=100):
     # Retry on errors that might be caused by stress testing.
     r = retry.Retry(
         backoff_factor=0.5,
-        method_whitelist=False,  # retry on any verb (including POST)
+        allowed_methods=None,  # retry on any verb (including POST)
         status_forcelist={
             429,  # concurrent_spawn_limit returns a 429
             503,  # if the hub container crashes we get a 503

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,9 @@ commands =
 
 [testenv:hub-stress-test]
 basepython = python3.12
+allowlist_externals =
+    cat
+    rm
 setenv =
     JUPYTERHUB_API_TOKEN=test
     JUPYTERHUB_ENDPOINT=https://notebooks.foo.com/hub/api

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     flake8 scripts
 
 [testenv:hub-stress-test]
-basepython = python3.7
+basepython = python3.12
 setenv =
     JUPYTERHUB_API_TOKEN=test
     JUPYTERHUB_ENDPOINT=https://notebooks.foo.com/hub/api


### PR DESCRIPTION
Without the added restriction, the latest version of `urllib3` gets installed, causing the following issue:

```
2025-01-15 15:18:41,356 INFO [hub-stress-test] Took 0.000 seconds to run_stress_test
2025-01-15 15:18:41,356 ERROR [hub-stress-test] Retry.__init__() got an unexpected keyword argument 'method_whitelist'
Traceback (most recent call last):
  File "/home/paul/jupyter-tools/scripts/hub-stress-test.py", line 665, in main
    run_stress_test(args.count, args.batch_size, args.token,
  File "/home/paul/jupyter-tools/scripts/hub-stress-test.py", line 198, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/paul/jupyter-tools/scripts/hub-stress-test.py", line 521, in run_stress_test
    session = get_session(token, dry_run=dry_run)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/paul/jupyter-tools/scripts/hub-stress-test.py", line 227, in get_session
    r = retry.Retry(
        ^^^^^^^^^^^^
TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'
```

This workaround results in the following warning, but the script can be run without errors.

```
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
  r = retry.Retry(
```